### PR TITLE
Add camera usage description to iOS sample

### DIFF
--- a/ios/health-monitor-app/Info.plist
+++ b/ios/health-monitor-app/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>FoodLoggerApp</string>
+    <key>NSCameraUsageDescription</key>
+    <string>We need camera access so you can take photos of your meals.</string>
+</dict>
+</plist>

--- a/ios/health-monitor-app/README.md
+++ b/ios/health-monitor-app/README.md
@@ -17,3 +17,22 @@ Supabase interactions are mocked.
 
 This code can serve as a starting point for integrating the real Supabase SDK
 and later expanding the application with additional features.
+
+## Configuration
+
+Create an `Info.plist` file in the project root (next to `FoodLoggerApp.swift`) with the following contents:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>FoodLoggerApp</string>
+    <key>NSCameraUsageDescription</key>
+    <string>We need camera access so you can take photos of your meals.</string>
+</dict>
+</plist>
+```
+
+The `NSCameraUsageDescription` key is required for camera access on iOS. Without it, the app will crash when attempting to take a photo.


### PR DESCRIPTION
## Summary
- add Info.plist with `NSCameraUsageDescription`
- document Info.plist configuration in the iOS README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d8dda81b4832982fcb5ce48b61787